### PR TITLE
Allow Containers to belong_to a User xor Group

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,10 +26,6 @@ class ApplicationController < ActionController::Base
     token_param.user || raise(UserMissing)
   end
 
-  def access_tag_param
-    AccessTag.find_by_name(params.require(:tag))
-  end
-
   def token_param
     token = authenticate_with_http_token { |t| t }
     JsonWebToken::Token.new(token || params[:flight_sso_token])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,7 +41,7 @@ class ApplicationController < ActionController::Base
   end
 
   def scope
-    raw = params.permit(:scope)[:scope].to_sym
+    raw = params.permit(:scope)[:scope]&.to_sym
     return nil unless [:user, :group, :public].include?(raw)
     raw
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,6 +23,8 @@ class ApplicationController < ActionController::Base
   end
 
   def token_param
-    JsonWebToken::Token.new(params[:flight_sso_token])
+    authenticate_with_http_token do |token|
+      JsonWebToken::Token.new(token || params[:flight_sso_token])
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,12 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  rescue_from CanCan::AccessDenied do |exp|
+    respond_to do |format|
+      format.json { head :forbidden }
+    end
+  end
+
   def current_user
     token_param.user
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,6 +30,15 @@ class ApplicationController < ActionController::Base
     token_param.user || raise(UserMissing)
   end
 
+  def current_group
+    return nil unless params[:group]
+    if params.require(:group) == 'public'
+      public_group
+    else
+      current_user.default_group
+    end
+  end
+
   def token_param
     token = authenticate_with_http_token { |t| t }
     JsonWebToken::Token.new(token || params[:flight_sso_token])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,19 +22,11 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def self.load_tag_containers(**opts)
-    before_action(**opts) do
-      @containers ||= begin
-        Container.where(access_tag: current_tag, group: current_user.groups)
-      end
-    end
-  end
-
   def current_user
     token_param.user || raise(UserMissing)
   end
 
-  def current_tag
+  def access_tag_param
     AccessTag.find_by_name(params.require(:tag))
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,8 +23,7 @@ class ApplicationController < ActionController::Base
   end
 
   def token_param
-    authenticate_with_http_token do |token|
-      JsonWebToken::Token.new(token || params[:flight_sso_token])
-    end
+    token = authenticate_with_http_token { |t| t }
+    JsonWebToken::Token.new(token || params[:flight_sso_token])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,10 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def public_group
+    Group.find_by_name('public')
+  end
+
   def current_user
     token_param.user || raise(UserMissing)
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,12 +31,19 @@ class ApplicationController < ActionController::Base
   end
 
   def current_group
-    return nil unless params[:group]
-    if params.require(:group) == 'public'
+    if scope == :public
       public_group
-    else
+    elsif scope == :group
       current_user.default_group
+    else
+      nil
     end
+  end
+
+  def scope
+    raw = params.permit(:scope)[:scope].to_sym
+    return nil unless [:user, :group, :public].include?(raw)
+    raw
   end
 
   def token_param

--- a/app/controllers/concerns/has_controller_tag.rb
+++ b/app/controllers/concerns/has_controller_tag.rb
@@ -9,6 +9,10 @@ module HasControllerTag
     Container.where(access_tag: access_tag_param, **owner_param_hash).first
   end
 
+  def current_containers
+    current_user.containers.where(access_tag: access_tag_param)
+  end
+
   private
 
   def owner_param_hash

--- a/app/controllers/concerns/has_controller_tag.rb
+++ b/app/controllers/concerns/has_controller_tag.rb
@@ -25,8 +25,8 @@ module HasControllerTag
   private
 
   def owner_param_hash
-    if params[:group]
-      { group: current_user.default_group }
+    if current_group
+      { group: current_group }
     else
       { user: current_user }
     end

--- a/app/controllers/concerns/has_controller_tag.rb
+++ b/app/controllers/concerns/has_controller_tag.rb
@@ -6,7 +6,7 @@ module HasControllerTag
   end
 
   def current_container
-    Container.where(access_tag: access_tag_param, **owner_param_hash).first
+    Container.find_by(access_tag: access_tag_param, **owner_param_hash)
   end
 
   def current_containers

--- a/app/controllers/concerns/has_controller_tag.rb
+++ b/app/controllers/concerns/has_controller_tag.rb
@@ -13,6 +13,15 @@ module HasControllerTag
     current_user.containers.where(access_tag: access_tag_param)
   end
 
+  def current_blobs
+    containers = if params[:list_all_tagged_blobs]
+                   current_containers
+                 else
+                   current_container
+                 end
+    Blob.where(container: containers)
+  end
+
   private
 
   def owner_param_hash

--- a/app/controllers/concerns/has_controller_tag.rb
+++ b/app/controllers/concerns/has_controller_tag.rb
@@ -14,12 +14,8 @@ module HasControllerTag
   end
 
   def current_blobs
-    containers = if params[:list_all_tagged_blobs]
-                   current_containers
-                 else
-                   current_container
-                 end
-    Blob.where(container: containers)
+    ctr_opt = scope.nil? ? current_containers : current_container
+    Blob.where(container: ctr_opt)
   end
 
   private

--- a/app/controllers/concerns/has_controller_tag.rb
+++ b/app/controllers/concerns/has_controller_tag.rb
@@ -1,0 +1,21 @@
+module HasControllerTag
+  extend ActiveSupport::Concern
+
+  def access_tag_param
+    AccessTag.find_by_name(params.require(:tag))
+  end
+
+  def current_container
+    Container.where(access_tag: access_tag_param, **owner_param_hash).first
+  end
+
+  private
+
+  def owner_param_hash
+    if params[:group]
+      { group: current_user.default_group }
+    else
+      { user: current_user }
+    end
+  end
+end

--- a/app/controllers/containers_controller.rb
+++ b/app/controllers/containers_controller.rb
@@ -1,8 +1,8 @@
 class ContainersController < ApplicationController
-  load_resource :container, except: :index
-  load_and_authorize_resource :blob, except: :index
-  before_action(except: :index) { @container ||= @blob.container }
-  authorize_resource :container, except: :index
+  load_resource :container
+  load_and_authorize_resource :blob
+  before_action { @container ||= @blob.container }
+  authorize_resource :container
 
   def show
     render json: ContainerSerializer.new(@container)

--- a/app/controllers/containers_controller.rb
+++ b/app/controllers/containers_controller.rb
@@ -4,14 +4,6 @@ class ContainersController < ApplicationController
   before_action(except: :index) { @container ||= @blob.container }
   authorize_resource :container, except: :index
 
-  # INDEX: Action Only
-  # Loads the containers based on the current user and tag
-  load_tag_containers only: :index
-
-  def index
-    render json: ContainerSerializer.new(@containers)
-  end
-
   def show
     render json: ContainerSerializer.new(@container)
   end

--- a/app/controllers/tag/blobs_controller.rb
+++ b/app/controllers/tag/blobs_controller.rb
@@ -1,13 +1,13 @@
 
 module Tag
   class BlobsController < ApplicationController
-    load_tag_containers
-    before_action do
-      @blobs ||= @containers.map(&:blobs).flatten
-    end
-
     def index
-      render json: BlobSerializer.new(@blobs)
+      render json: BlobSerializer.new(
+        current_user.containers
+                    .where(access_tag: access_tag_param)
+                    .map(&:blobs)
+                    .flatten
+      )
     end
   end
 end

--- a/app/controllers/tag/blobs_controller.rb
+++ b/app/controllers/tag/blobs_controller.rb
@@ -1,13 +1,10 @@
 
 module Tag
   class BlobsController < ApplicationController
+    include HasControllerTag
+
     def index
-      render json: BlobSerializer.new(
-        current_user.containers
-                    .where(access_tag: access_tag_param)
-                    .map(&:blobs)
-                    .flatten
-      )
+      render json: BlobSerializer.new(current_blobs)
     end
   end
 end

--- a/app/controllers/tag/containers_controller.rb
+++ b/app/controllers/tag/containers_controller.rb
@@ -7,5 +7,23 @@ module Tag
                     .where(access_tag: access_tag_param)
       )
     end
+
+    def show
+      render json: ContainerSerializer.new(
+        Container.where(
+          user: current_user,
+          access_tag: access_tag_param
+        ).first
+      )
+    end
+
+    def show_group
+      render json: ContainerSerializer.new(
+        Container.where(
+          group: current_user.default_group,
+          access_tag: access_tag_param
+        ).first
+      )
+    end
   end
 end

--- a/app/controllers/tag/containers_controller.rb
+++ b/app/controllers/tag/containers_controller.rb
@@ -1,0 +1,10 @@
+
+module Tag
+  class ContainersController < ApplicationController
+    load_tag_containers
+
+    def index
+      render json: ContainerSerializer.new(@containers)
+    end
+  end
+end

--- a/app/controllers/tag/containers_controller.rb
+++ b/app/controllers/tag/containers_controller.rb
@@ -4,10 +4,7 @@ module Tag
     include HasControllerTag
 
     def index
-      render json: ContainerSerializer.new(
-        current_user.containers
-                    .where(access_tag: access_tag_param)
-      )
+      render json: ContainerSerializer.new(current_containers)
     end
 
     def show

--- a/app/controllers/tag/containers_controller.rb
+++ b/app/controllers/tag/containers_controller.rb
@@ -1,6 +1,8 @@
 
 module Tag
   class ContainersController < ApplicationController
+    include HasControllerTag
+
     def index
       render json: ContainerSerializer.new(
         current_user.containers
@@ -9,21 +11,7 @@ module Tag
     end
 
     def show
-      render json: ContainerSerializer.new(
-        Container.where(
-          user: current_user,
-          access_tag: access_tag_param
-        ).first
-      )
-    end
-
-    def show_group
-      render json: ContainerSerializer.new(
-        Container.where(
-          group: current_user.default_group,
-          access_tag: access_tag_param
-        ).first
-      )
+      render json: ContainerSerializer.new(current_container)
     end
   end
 end

--- a/app/controllers/tag/containers_controller.rb
+++ b/app/controllers/tag/containers_controller.rb
@@ -1,10 +1,11 @@
 
 module Tag
   class ContainersController < ApplicationController
-    load_tag_containers
-
     def index
-      render json: ContainerSerializer.new(@containers)
+      render json: ContainerSerializer.new(
+        current_user.containers
+                    .where(access_tag: access_tag_param)
+      )
     end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -34,12 +34,12 @@ class Ability
       can :manage, :all
     elsif user
       can [:show, :upload], Container do |container|
-        container.group == user.group
+        user.has_container?(container)
       end
       can :index, Container
       can :index, Blob
       can [:show, :download], Blob do |blob|
-        blob.container.group == user.group
+        user.has_container?(blob.container)
       end
     end
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -34,12 +34,12 @@ class Ability
       can :manage, :all
     elsif user
       can [:show, :upload], Container do |container|
-        user.has_container?(container)
+        container.has_user?(user)
       end
       can :index, Container
       can :index, Blob
       can [:show, :download], Blob do |blob|
-        user.has_container?(blob.container)
+        blob.container.has_user?(user)
       end
     end
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -36,7 +36,6 @@ class Ability
       can [:show, :upload], Container do |container|
         container.has_user?(user)
       end
-      can :index, Container
       can :index, Blob
       can [:show, :download], Blob do |blob|
         blob.container.has_user?(user)

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -1,6 +1,9 @@
 require 'aws-sdk-s3'
 
 class Container < ApplicationRecord
+  belongs_to :group, optional: true
+  belongs_to :user, optional: true
+
   validates :user, absence: true, if: :group
   validates :user, presence: true, unless: :group
 
@@ -10,6 +13,19 @@ class Container < ApplicationRecord
   has_many :blobs
   belongs_to :access_tag
 
-  belongs_to :group, optional: true
-  belongs_to :user, optional: true
+  def users
+    if owner.is_a? User
+      User.where(id: user)
+    else
+      group.users
+    end
+  end
+
+  def has_user?(user)
+    users.include?(user)
+  end
+
+  def owner
+    user || group
+  end
 end

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -1,7 +1,15 @@
 require 'aws-sdk-s3'
 
 class Container < ApplicationRecord
+  validates :user, absence: true, if: :group
+  validates :user, presence: true, unless: :group
+
+  validates :group, absence: true, if: :user
+  validates :group, presence: true, unless: :user
+
   has_many :blobs
   belongs_to :access_tag
-  belongs_to :group
+
+  belongs_to :group, optional: true
+  belongs_to :user, optional: true
 end

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -1,14 +1,12 @@
 require 'aws-sdk-s3'
 
 class Container < ApplicationRecord
-  belongs_to :group, optional: true
-  belongs_to :user, optional: true
-
-  validates :user, absence: true, if: :group
-  validates :user, presence: true, unless: :group
-
-  validates :group, absence: true, if: :user
-  validates :group, presence: true, unless: :user
+  # validates presence user XOR group
+  [owners = [:user, :group], owners.reverse].each do |owner1, owner2|
+    belongs_to owner1, optional: true
+    validates owner1, absence: true, if: owner2
+    validates owner1, presence: true, unless: owner2
+  end
 
   has_many :blobs
   belongs_to :access_tag

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,4 +1,8 @@
 class Group < ApplicationRecord
   has_many :containers
   has_many :users
+
+  def users
+    name == 'public' ? User.all : super
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,15 @@
 class User < ApplicationRecord
+  has_many :user_containers, class_name: 'Container'
+
   belongs_to :group, optional: true
 
-  has_many :containers, through: :group
+  def group_containers
+    group&.containers || []
+  end
+
+  def containers
+    [user_containers, group_containers].flatten
+  end
 
   # Adds the "groups" method so it can be used in the refactoring. This will
   # likely become an many-to-many relationship

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,19 +1,25 @@
 class User < ApplicationRecord
-  has_many :user_containers, class_name: 'Container'
-
-  belongs_to :group, optional: true
-
-  def group_containers
-    group&.containers || []
-  end
-
-  def containers
-    [user_containers, group_containers].flatten
-  end
+  belongs_to :default_group,
+             optional: true,
+             foreign_key: 'group_id',
+             class_name: 'Group'
+  has_many   :user_containers, class_name: 'Container'
 
   # Adds the "groups" method so it can be used in the refactoring. This will
   # likely become an many-to-many relationship
   def groups
-    [group].reject(&:nil?)
+    [default_group].reject(&:nil?)
+  end
+
+  def containers
+    user_containers.or(group_containers)
+  end
+
+  def has_container?(container)
+    containers.include?(container)
+  end
+
+  def group_containers
+    Container.where(group: (default_group || -1))
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,10 +15,6 @@ class User < ApplicationRecord
     user_containers.or(group_containers)
   end
 
-  def has_container?(container)
-    containers.include?(container)
-  end
-
   def group_containers
     Container.where(group: (default_group || -1))
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,10 +12,14 @@ class User < ApplicationRecord
   end
 
   def containers
-    user_containers.or(group_containers)
+    user_containers.or(group_containers).or(public_containers)
   end
 
   def group_containers
     Container.where(group: (default_group || -1))
+  end
+
+  def public_containers
+    Group.find_by_name('public').containers
   end
 end

--- a/app/serializers/blob_serializer.rb
+++ b/app/serializers/blob_serializer.rb
@@ -1,12 +1,12 @@
 class BlobSerializer < ApplicationSerializer
   attributes :checksum
-  attribute :size, &:byte_size
-  attribute :filename { |o| o.filename.to_s }
+  attribute(:size, &:byte_size)
+  attribute(:filename) { |o| o.filename.to_s }
 
   belongs_to :container, links: {
     related: proc { |b| urls.url_for(b.container) }
   }
 
-  link :self { |b| urls.blob_url(b) }
-  link :download { |b| urls.download_blob_url(b) }
+  link(:self) { |b| urls.blob_url(b) }
+  link(:download) { |b| urls.download_blob_url(b) }
 end

--- a/app/serializers/blob_serializer.rb
+++ b/app/serializers/blob_serializer.rb
@@ -1,6 +1,6 @@
 class BlobSerializer < ApplicationSerializer
   attributes :checksum
-  attribute(:size, &:byte_size)
+  attribute(:byte_size)
   attribute(:filename) { |o| o.filename.to_s }
 
   belongs_to :container, links: {

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,6 +54,7 @@ Rails.application.configure do
 
   # Develop on local host
   Rails.application.routes.default_url_options[:host] = 'localhost:3000'
+  Rails.application.routes.default_url_options[:protocol] = 'http'
 
   # Store files on Amazon S3.
   config.active_storage.service = :amazon

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,6 +89,10 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  # Set the default url from the environment
+  Figaro.require_keys("default_host_url")
+  Rails.application.routes.default_url_options[:host] = Figaro.env.default_host_url
+
   # Store files on Amazon S3.
   config.active_storage.service = :amazon
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,6 +92,7 @@ Rails.application.configure do
   # Set the default url from the environment
   Figaro.require_keys("default_host_url")
   Rails.application.routes.default_url_options[:host] = Figaro.env.default_host_url
+  Rails.application.routes.default_url_options[:protocol] = 'https'
 
   # Store files on Amazon S3.
   config.active_storage.service = :amazon

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,27 +15,10 @@ Rails.application.routes.draw do
   end
 
   namespace :tag, path: :tags do
-    scope ':tag', controller: :containers do
-      get '/', action: :index
-      resources :blobs, only: :index, defaults: { list_all_tagged_blobs: true }
-
-      scope :user, controller: :containers do
-        get '/', action: :show
-
-        resources :blobs, only: :index
-      end
-
-      scope :group, controller: :containers, defaults: { group: :true } do
-        get '/', action: :show
-
-        resources :blobs, only: :index
-      end
-
-      scope :public, controller: :containers, defaults: { group: 'public' } do
-        get '/', action: :show
-
-        resources :blobs, only: :index
-      end
+    scope ':tag' do
+      get '/', controller: :container, action: :index
+      resource :container, controller: :containers, only: :show
+      resources :blobs, only: :index
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
     scope ':tag', controller: :containers do
       get '/', action: :index
       get '/user', action: :show
-      get '/group', action: :show_group
+      get '/group', action: :show, defaults: { group: :true }
 
       resources :blobs, only: :index
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
   namespace :tag, path: :tags do
     scope ':tag', controller: :containers do
       get '/', action: :index
+      get '/user', action: :show
+      get '/group', action: :show_group
 
       resources :blobs, only: :index
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,10 +14,10 @@ Rails.application.routes.draw do
     resources :blobs, only: :index
   end
 
-  match 'tags/:tag', via: :get, controller: :containers, action: :index
-
   namespace :tag, path: :tags do
-    scope ':tag' do
+    scope ':tag', controller: :containers do
+      get '/', action: :index
+
       resources :blobs, only: :index
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,12 @@ Rails.application.routes.draw do
 
         resources :blobs, only: :index
       end
+
+      scope :public, controller: :containers, defaults: { group: 'public' } do
+        get '/', action: :show
+
+        resources :blobs, only: :index
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
 
   namespace :tag, path: :tags do
     scope ':tag' do
-      get '/', controller: :container, action: :index
+      get '/', controller: :containers, action: :index
       resource :container, controller: :containers, only: :show
       resources :blobs, only: :index
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,10 +17,19 @@ Rails.application.routes.draw do
   namespace :tag, path: :tags do
     scope ':tag', controller: :containers do
       get '/', action: :index
-      get '/user', action: :show
-      get '/group', action: :show, defaults: { group: :true }
+      resources :blobs, only: :index, defaults: { list_all_tagged_blobs: true }
 
-      resources :blobs, only: :index
+      scope :user, controller: :containers do
+        get '/', action: :show
+
+        resources :blobs, only: :index
+      end
+
+      scope :group, controller: :containers, defaults: { group: :true } do
+        get '/', action: :show
+
+        resources :blobs, only: :index
+      end
     end
   end
 end

--- a/db/migrate/20190318122733_add_user_containers.rb
+++ b/db/migrate/20190318122733_add_user_containers.rb
@@ -1,0 +1,8 @@
+class AddUserContainers < ActiveRecord::Migration[5.2]
+  def change
+    remove_index  :containers, [:access_tag_id, :group_id]
+    add_reference :containers, :user, null: true, foreign_key: true, index: true
+    add_index     :containers, [:access_tag_id, :group_id, :user_id], unique: true
+    change_column :containers, :group_id, :bigint, null: true
+  end
+end

--- a/db/migrate/20190318172029_fix_unique_tag_group_user_index.rb
+++ b/db/migrate/20190318172029_fix_unique_tag_group_user_index.rb
@@ -1,0 +1,7 @@
+class FixUniqueTagGroupUserIndex < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :containers, [:access_tag_id, :group_id, :user_id]
+    add_index :containers, [:access_tag_id, :group_id], unique: true
+    add_index :containers, [:access_tag_id, :user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_03_185040) do
+ActiveRecord::Schema.define(version: 2019_03_18_122733) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,10 +44,12 @@ ActiveRecord::Schema.define(version: 2019_03_03_185040) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "access_tag_id"
-    t.bigint "group_id", null: false
-    t.index ["access_tag_id", "group_id"], name: "index_containers_on_access_tag_id_and_group_id", unique: true
+    t.bigint "group_id"
+    t.bigint "user_id"
+    t.index ["access_tag_id", "group_id", "user_id"], name: "index_containers_on_access_tag_id_and_group_id_and_user_id", unique: true
     t.index ["access_tag_id"], name: "index_containers_on_access_tag_id"
     t.index ["group_id"], name: "index_containers_on_group_id"
+    t.index ["user_id"], name: "index_containers_on_user_id"
   end
 
   create_table "groups", force: :cascade do |t|
@@ -71,5 +73,6 @@ ActiveRecord::Schema.define(version: 2019_03_03_185040) do
   add_foreign_key "blobs", "containers"
   add_foreign_key "containers", "access_tags"
   add_foreign_key "containers", "groups"
+  add_foreign_key "containers", "users"
   add_foreign_key "users", "groups"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_18_122733) do
+ActiveRecord::Schema.define(version: 2019_03_18_172029) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,7 +46,8 @@ ActiveRecord::Schema.define(version: 2019_03_18_122733) do
     t.bigint "access_tag_id"
     t.bigint "group_id"
     t.bigint "user_id"
-    t.index ["access_tag_id", "group_id", "user_id"], name: "index_containers_on_access_tag_id_and_group_id_and_user_id", unique: true
+    t.index ["access_tag_id", "group_id"], name: "index_containers_on_access_tag_id_and_group_id", unique: true
+    t.index ["access_tag_id", "user_id"], name: "index_containers_on_access_tag_id_and_user_id", unique: true
     t.index ["access_tag_id"], name: "index_containers_on_access_tag_id"
     t.index ["group_id"], name: "index_containers_on_group_id"
     t.index ["user_id"], name: "index_containers_on_user_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,6 +6,8 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
+Group.create!(name: 'public')
+
 # Selectively load other db seeds based on the environment
 env_seeds = Rails.root.join( 'db', 'seeds', "#{Rails.env.downcase}.rb")
 load(env_seeds) if File.exists?(env_seeds)

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -1,11 +1,11 @@
 # Creates the test tag
-tag = ToolTag.create!(name: 'test-tag')
+tag = AccessTag.create!(name: 'test-tag')
 
 # Creates the group
 group = Group.create!(name: 'test-group')
 
 # Create a test container
-Container.create!(tool_tag: tag, group: group)
+Container.create!(access_tag: tag, group: group)
 
 # Creates the admin user
 User.create!(email: "admin@example.com", global_admin: true)


### PR DESCRIPTION
`Container`s can now join onto either a `User` xor `Group`. This join is exclusive to keep the authorisation logical complexity down. This establishes a single "owner" for each container. The uniqueness constraint between the access tag and group/user/owner has been maintained.

In addition to the above data structure changes, a bunch of end points for filtering by `tag` have been added. It is now possible to retrieve a owners' container and blobs of a particular tag.

A public group has been added, and can be filtered upon like an owner