### PR TITLE
Update the handling of tags and tagged containers

### DIFF
--- a/app/controllers/concerns/has_controller_tag.rb
+++ b/app/controllers/concerns/has_controller_tag.rb
@@ -1,16 +1,16 @@
 module HasControllerTag
   extend ActiveSupport::Concern
 
-  def access_tag_param
-    AccessTag.find_by_name(params.require(:tag))
+  def tag_param
+    Tag.find_by_name(params.require(:tag))
   end
 
   def current_container
-    Container.find_by(access_tag: access_tag_param, **owner_param_hash)
+    Container.find_by(tag: tag_param, **owner_param_hash)
   end
 
   def current_containers
-    current_user.containers.where(access_tag: access_tag_param)
+    current_user.containers.where(tag: tag_param)
   end
 
   def current_blobs

--- a/app/controllers/concerns/has_tagged_container.rb
+++ b/app/controllers/concerns/has_tagged_container.rb
@@ -2,11 +2,12 @@ module HasTaggedContainer
   extend ActiveSupport::Concern
 
   def tag_param
-    Tag.find_by_name(params.require(:tag))
+    Tag.find_by_name!(params.require(:tag))
   end
 
   def current_container
-    Container.find_by(tag: tag_param, **owner_param_hash)
+    c = Container.find_by(tag: tag_param, **owner_param_hash)
+    c || Container.create!(tag: tag_param, **owner_param_hash)
   end
 
   def current_containers

--- a/app/controllers/concerns/has_tagged_container.rb
+++ b/app/controllers/concerns/has_tagged_container.rb
@@ -1,4 +1,4 @@
-module HasControllerTag
+module HasTaggedContainer
   extend ActiveSupport::Concern
 
   def tag_param

--- a/app/controllers/containers_controller.rb
+++ b/app/controllers/containers_controller.rb
@@ -9,11 +9,10 @@ class ContainersController < ApplicationController
   end
 
   def upload
-    active_storage_blob = ActiveStorage::Blob.create_after_upload!(
-      io: request.body, filename: filename_param
-    )
-    blob = Blob.create!(
-      active_storage_blob: active_storage_blob, container: @container
+    blob = Blob.upload_and_create!(
+      io: request.body,
+      filename: filename_param,
+      container: @container
     )
     render json: BlobSerializer.new(blob)
   end

--- a/app/controllers/tagged/blobs_controller.rb
+++ b/app/controllers/tagged/blobs_controller.rb
@@ -1,7 +1,7 @@
 
-module Tag
+module Tagged
   class BlobsController < ApplicationController
-    include HasControllerTag
+    include HasTaggedContainer
 
     def index
       render json: BlobSerializer.new(current_blobs)

--- a/app/controllers/tagged/containers_controller.rb
+++ b/app/controllers/tagged/containers_controller.rb
@@ -1,7 +1,7 @@
 
-module Tag
+module Tagged
   class ContainersController < ApplicationController
-    include HasControllerTag
+    include HasTaggedContainer
 
     def index
       render json: ContainerSerializer.new(current_containers)

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,0 +1,15 @@
+class TagsController < ApplicationController
+  def index
+    render json: TagSerializer.new(Tag.all, is_collection: true)
+  end
+
+  def show
+    render json: TagSerializer.new(tag_param)
+  end
+
+  private
+
+  def tag_param
+    Tag.find(params.require(:id))
+  end
+end

--- a/app/models/blob.rb
+++ b/app/models/blob.rb
@@ -1,4 +1,9 @@
 class Blob < ApplicationRecord
+  def self.upload_and_create!(io:, filename:, container:)
+    as = ActiveStorage::Blob.create_after_upload!(io: io, filename: filename)
+    create!(active_storage_blob: as, container: container)
+  end
+
   belongs_to :container
   belongs_to :active_storage_blob, class_name: 'ActiveStorage::Blob'
   delegate_missing_to :active_storage_blob

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -11,6 +11,12 @@ class Container < ApplicationRecord
   has_many :blobs
   belongs_to :tag
 
+  # Dummy method for use in the serialization. This way the container can
+  # be determined for the model without checking its type first
+  def container
+    self
+  end
+
   def users
     if owner.is_a? User
       User.where(id: user)

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -9,7 +9,7 @@ class Container < ApplicationRecord
   end
 
   has_many :blobs
-  belongs_to :access_tag
+  belongs_to :tag
 
   def users
     if owner.is_a? User

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -17,6 +17,16 @@ class Container < ApplicationRecord
     self
   end
 
+  def scope
+    if group && group.name == 'public'
+      :public
+    elsif group
+      :group
+    else
+      :user
+    end
+  end
+
   def users
     if owner.is_a? User
       User.where(id: user)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,4 @@
-class AccessTag < ApplicationRecord
+class Tag < ApplicationRecord
   has_many :containers
 
   validates :name, presence: true, allow_blank: false, uniqueness: true

--- a/app/serializers/blob_serializer.rb
+++ b/app/serializers/blob_serializer.rb
@@ -1,7 +1,11 @@
+require 'concerns/serializes_with_tagged_scope'
+
 class BlobSerializer < ApplicationSerializer
+  include SerializesWithTaggedScope
+
   attributes :checksum
   attribute(:byte_size)
-  attribute(:filename) { |o| o.filename.to_s }
+  attribute(:filename) { |b| b.filename.to_s }
 
   belongs_to :container, links: {
     related: proc { |b| urls.url_for(b.container) }

--- a/app/serializers/concerns/serializes_with_tagged_scope.rb
+++ b/app/serializers/concerns/serializes_with_tagged_scope.rb
@@ -1,0 +1,8 @@
+module SerializesWithTaggedScope
+  extend ActiveSupport::Concern
+
+  included do
+    attribute(:tag_name) { |o| o.container.tag.name }
+    belongs_to :tag { |o| o.container.tag }
+  end
+end

--- a/app/serializers/concerns/serializes_with_tagged_scope.rb
+++ b/app/serializers/concerns/serializes_with_tagged_scope.rb
@@ -3,6 +3,7 @@ module SerializesWithTaggedScope
 
   included do
     attribute(:tag_name) { |o| o.container.tag.name }
-    belongs_to :tag { |o| o.container.tag }
+    attribute(:scope) { |o| o.container.scope }
+    belongs_to(:tag) { |o| o.container.tag }
   end
 end

--- a/app/serializers/concerns/serializes_with_tagged_scope.rb
+++ b/app/serializers/concerns/serializes_with_tagged_scope.rb
@@ -4,6 +4,10 @@ module SerializesWithTaggedScope
   included do
     attribute(:tag_name) { |o| o.container.tag.name }
     attribute(:scope) { |o| o.container.scope }
-    belongs_to(:tag) { |o| o.container.tag }
+
+    tag_kwargs = {
+      links: { related: proc { |o| urls.tag_url(o.container.tag) } }
+    }
+    belongs_to(:tag, **tag_kwargs) { |o| o.container.tag }
   end
 end

--- a/app/serializers/container_serializer.rb
+++ b/app/serializers/container_serializer.rb
@@ -1,7 +1,7 @@
-class ContainerSerializer < ApplicationSerializer
-  include FastJsonapi::ObjectSerializer
+require 'concerns/serializes_with_tagged_scope'
 
-  attribute(:tag) { |c| c.tag.name }
+class ContainerSerializer < ApplicationSerializer
+  include SerializesWithTaggedScope
 
   link(:self) { |c| urls.url_for(c) }
 

--- a/app/serializers/container_serializer.rb
+++ b/app/serializers/container_serializer.rb
@@ -1,7 +1,7 @@
 class ContainerSerializer < ApplicationSerializer
   include FastJsonapi::ObjectSerializer
 
-  attribute(:tag) { |c| c.access_tag.name }
+  attribute(:tag) { |c| c.tag.name }
 
   link(:self) { |c| urls.url_for(c) }
 

--- a/app/serializers/tag_serializer.rb
+++ b/app/serializers/tag_serializer.rb
@@ -1,0 +1,3 @@
+class TagSerializer < ApplicationSerializer
+  attribute :name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
     resources :blobs, only: :index
   end
 
-  namespace :tag, path: :tags do
+  namespace :tagged do
     scope ':tag' do
       get '/', controller: :containers, action: :index
       resource :container, controller: :containers, only: :show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
     resources :blobs, only: :index
   end
 
+  resources :tags, only: [:show, :index]
+
   namespace :tagged do
     scope ':tag' do
       get '/', controller: :containers, action: :index

--- a/db/migrate/20190322104604_rename_access_tag_to_tag.rb
+++ b/db/migrate/20190322104604_rename_access_tag_to_tag.rb
@@ -1,0 +1,6 @@
+class RenameAccessTagToTag < ActiveRecord::Migration[5.2]
+  def change
+    rename_table :access_tags, :tags
+    rename_column :containers, :access_tag_id, :tag_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_18_172029) do
+ActiveRecord::Schema.define(version: 2019_03_22_104604) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "access_tags", force: :cascade do |t|
-    t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["name"], name: "index_access_tags_on_name", unique: true
-  end
 
   create_table "active_storage_blobs", force: :cascade do |t|
     t.string "key", null: false
@@ -43,13 +36,13 @@ ActiveRecord::Schema.define(version: 2019_03_18_172029) do
   create_table "containers", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "access_tag_id"
+    t.bigint "tag_id"
     t.bigint "group_id"
     t.bigint "user_id"
-    t.index ["access_tag_id", "group_id"], name: "index_containers_on_access_tag_id_and_group_id", unique: true
-    t.index ["access_tag_id", "user_id"], name: "index_containers_on_access_tag_id_and_user_id", unique: true
-    t.index ["access_tag_id"], name: "index_containers_on_access_tag_id"
     t.index ["group_id"], name: "index_containers_on_group_id"
+    t.index ["tag_id", "group_id"], name: "index_containers_on_tag_id_and_group_id", unique: true
+    t.index ["tag_id", "user_id"], name: "index_containers_on_tag_id_and_user_id", unique: true
+    t.index ["tag_id"], name: "index_containers_on_tag_id"
     t.index ["user_id"], name: "index_containers_on_user_id"
   end
 
@@ -58,6 +51,13 @@ ActiveRecord::Schema.define(version: 2019_03_18_172029) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_groups_on_name", unique: true
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -72,8 +72,8 @@ ActiveRecord::Schema.define(version: 2019_03_18_172029) do
 
   add_foreign_key "blobs", "active_storage_blobs"
   add_foreign_key "blobs", "containers"
-  add_foreign_key "containers", "access_tags"
   add_foreign_key "containers", "groups"
+  add_foreign_key "containers", "tags"
   add_foreign_key "containers", "users"
   add_foreign_key "users", "groups"
 end

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -1,11 +1,11 @@
 # Creates the test tag
-tag = AccessTag.create!(name: 'test-tag')
+tag = Tag.create!(name: 'test-tag')
 
 # Creates the group
 group = Group.create!(name: 'test-group')
 
 # Create a test container
-Container.create!(access_tag: tag, group: group)
+Container.create!(tag: tag, group: group)
 
 # Creates the admin user
 User.create!(email: "admin@example.com", global_admin: true)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -23,11 +23,11 @@ FactoryBot.define do
   end
 
   factory :container do
-    access_tag
+    tag
     group
   end
 
-  factory :access_tag do
+  factory :tag do
     name { "test-cloud-application" }
   end
 end

--- a/spec/models/access_tag.rb
+++ b/spec/models/access_tag.rb
@@ -1,4 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe AccessTag, type: :model do
-end


### PR DESCRIPTION
The old `AccessTag` model has been renamed `Tag` as this makes the routing a bit easier and conventional.

The old `tags/:tag` end points have been renamed `tagged/:tag`. This is b/c they actually return tagged `Containers`/`Blobs` not `Tags`. This frees up the `tags` end point to return `Tags` as expected. There is now `index` and `show` end points which fixes #8.

The handling of tagged containers have also been updated. As the `Container` may not exist in advance, they can now be implicitly created. This only applies to fetching a single container by its tag (and scope). The `index` and get by `id` end points do not create containers. fixes #3 

Finally, the `tag` and `scope` details are serialized onto the `Blob` and `Container`. This removes the need for a separate request for these details. Fixes #4 