### PR TITLE
Split the access control into readble? and writable?

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -33,13 +33,19 @@ class Ability
     if user&.global_admin?
       can :manage, :all
     elsif user
-      can [:show, :upload], Container do |container|
-        container.has_user?(user)
+      can :show, Container do |container|
+        container.readable?(user)
+      end
+      can :upload, Container do |container|
+        container.writable?(user)
       end
       can :index, Blob
       can :index, Container
-      can [:show, :download, :destroy], Blob do |blob|
-        blob.container.has_user?(user)
+      can [:show, :download], Blob do |blob|
+        blob.container.readable?(user)
+      end
+      can :destroy, Blob do |blob|
+        blob.container.writable?(user)
       end
     end
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -38,7 +38,7 @@ class Ability
       end
       can :index, Blob
       can :index, Container
-      can [:show, :download], Blob do |blob|
+      can [:show, :download, :destroy], Blob do |blob|
         blob.container.has_user?(user)
       end
     end

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -27,16 +27,14 @@ class Container < ApplicationRecord
     end
   end
 
-  def users
-    if owner.is_a? User
-      User.where(id: user)
+  def readable?(other)
+    if owner.is_a?(User) && owner == other
+      true
+    elsif owner.is_a?(Group) && other.users.include?(other)
+      true
     else
-      group.users
+      false
     end
-  end
-
-  def readable?(user)
-    users.include?(user)
   end
 
   def writable?(user)

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -44,7 +44,7 @@ class Container < ApplicationRecord
   def access?(method, other)
     if owner.is_a?(User) && owner == other
       true
-    elsif owner.is_a?(Group) && other.public_send(method, other)
+    elsif owner.is_a?(Group) && owner.public_send(method, other)
       true
     else
       false

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -28,20 +28,26 @@ class Container < ApplicationRecord
   end
 
   def readable?(other)
-    if owner.is_a?(User) && owner == other
-      true
-    elsif owner.is_a?(Group) && other.users.include?(other)
-      true
-    else
-      false
-    end
+    access?(:readable?, other)
   end
 
-  def writable?(user)
-    readable?(user)
+  def writable?(other)
+    access?(:writable?, other)
   end
 
   def owner
     user || group
+  end
+
+  private
+
+  def access?(method, other)
+    if owner.is_a?(User) && owner == other
+      true
+    elsif owner.is_a?(Group) && other.public_send(method, other)
+      true
+    else
+      false
+    end
   end
 end

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -35,8 +35,12 @@ class Container < ApplicationRecord
     end
   end
 
-  def has_user?(user)
+  def readable?(user)
     users.include?(user)
+  end
+
+  def writable?(user)
+    readable?(user)
   end
 
   def owner

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -7,4 +7,12 @@ class Group < ApplicationRecord
   def users
     name == 'public' ? User.all : super
   end
+
+  def readable?(other)
+    users.include?(other)
+  end
+
+  def writable?(other)
+    readable?(other)
+  end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,15 +4,23 @@ class Group < ApplicationRecord
   has_many :containers
   has_many :users, foreign_key: 'default_group_id'
 
-  def users
-    name == 'public' ? User.all : super
-  end
-
   def readable?(other)
-    users.include?(other)
+    if self.public?
+      true
+    else
+      users.include?(other)
+    end
   end
 
   def writable?(other)
-    readable?(other)
+    if self.public?
+      false
+    else
+      user.include?(other)
+    end
+  end
+
+  def public?
+    name == 'public'
   end
 end


### PR DESCRIPTION
This resolves the access control around the public group, fixes #2. There is now separate access for `read` action and `write` actions. The `container` is the primary access point for determining this, but it will delegate the heaving lifting to `Group` if required. Naturally a user can read or write to containers they directly own.

NOTE: You may notice that there is no mention of global admins on `Group` or `Container`. This is b/c global admin access is directly given by `cancancan`. This means the underlining checks do not need to accommodate this edge case. This greatly simplifies the code base and keeps the global admin footprint as small as possible. 