### PR TITLE
Update the access control and implement Protected Blobs

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -33,20 +33,14 @@ class Ability
     if user&.global_admin?
       can :manage, :all
     elsif user
-      can :show, Container do |container|
-        container.readable?(user)
+      [Blob, Container].each do |model|
+        can :index, model
+        can :show, model { |o| o.readable?(user) }
       end
-      can :upload, Container do |container|
-        container.writable?(user)
-      end
-      can :index, Blob
-      can :index, Container
-      can [:show, :download], Blob do |blob|
-        blob.readable?(user)
-      end
-      can :destroy, Blob do |blob|
-        blob.writable?(user)
-      end
+
+      can :download, Blob { |b| b.readable?(user) }
+      can :destroy, Blob { |b| b.writable?(user) }
+      can :upload, Container { |c| c.writable?(user)  }
     end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -42,10 +42,10 @@ class Ability
       can :index, Blob
       can :index, Container
       can [:show, :download], Blob do |blob|
-        blob.container.readable?(user)
+        blob.readable?(user)
       end
       can :destroy, Blob do |blob|
-        blob.container.writable?(user)
+        blob.writable?(user)
       end
     end
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -31,16 +31,16 @@ class Ability
 
     # Protect against the nil user
     if user&.global_admin?
-      can :manage, :all
+      can(:manage, :all)
     elsif user
       [Blob, Container].each do |model|
-        can :index, model
-        can :show, model { |o| o.readable?(user) }
+        can(:index, model)
+        can(:show, model) { |o| o.readable?(user) }
       end
 
-      can :download, Blob { |b| b.readable?(user) }
-      can :destroy, Blob { |b| b.writable?(user) }
-      can :upload, Container { |c| c.writable?(user)  }
+      can(:download, Blob) { |b| b.readable?(user) }
+      can(:destroy, Blob) { |b| b.writable?(user) }
+      can(:upload, Container) { |c| c.writable?(user)  }
     end
   end
 end

--- a/app/models/blob.rb
+++ b/app/models/blob.rb
@@ -10,6 +10,8 @@ class Blob < ApplicationRecord
   belongs_to :active_storage_blob, class_name: 'ActiveStorage::Blob'
   delegate_missing_to :active_storage_blob
 
+  alias_attribute :protected?, :protected
+
   after_destroy :purge_active_storage_blob
 
   def reabable?(other)

--- a/app/models/blob.rb
+++ b/app/models/blob.rb
@@ -14,8 +14,8 @@ class Blob < ApplicationRecord
 
   after_destroy :purge_active_storage_blob
 
-  def reabable?(other)
-    access?(:reable?, other)
+  def readable?(other)
+    access?(:readable?, other)
   end
 
   def writable?(other)

--- a/app/models/blob.rb
+++ b/app/models/blob.rb
@@ -17,6 +17,7 @@ class Blob < ApplicationRecord
   end
 
   def writable?(other)
+    return false if self.protected?
     access?(:writable?, other)
   end
 

--- a/app/models/blob.rb
+++ b/app/models/blob.rb
@@ -12,9 +12,21 @@ class Blob < ApplicationRecord
 
   after_destroy :purge_active_storage_blob
 
+  def reabable?(other)
+    access?(:reable?, other)
+  end
+
+  def writable?(other)
+    access?(:writable?, other)
+  end
+
   private
 
   def purge_active_storage_blob
     active_storage_blob.purge
+  end
+
+  def access?(method, other)
+    container.public_send(method, other)
   end
 end

--- a/app/models/blob.rb
+++ b/app/models/blob.rb
@@ -14,6 +14,10 @@ class Blob < ApplicationRecord
 
   after_destroy :purge_active_storage_blob
 
+  def protected
+    super() || container.restricted?
+  end
+
   def readable?(other)
     access?(:readable?, other)
   end

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -32,6 +32,7 @@ class Container < ApplicationRecord
   end
 
   def writable?(other)
+    return false if tag.restricted?
     access?(:writable?, other)
   end
 

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -8,6 +8,8 @@ class Container < ApplicationRecord
     validates owner1, presence: true, unless: owner2
   end
 
+  delegate :restricted, :restricted?, to: :tag
+
   has_many :blobs
   belongs_to :tag
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -2,4 +2,6 @@ class Tag < ApplicationRecord
   has_many :containers
 
   validates :name, presence: true, allow_blank: false, uniqueness: true
+
+  alias_attribute :restricted?, :restricted
 end

--- a/app/serializers/blob_serializer.rb
+++ b/app/serializers/blob_serializer.rb
@@ -6,6 +6,7 @@ class BlobSerializer < ApplicationSerializer
   attributes :checksum
   attribute(:byte_size)
   attribute(:filename) { |b| b.filename.to_s }
+  attribute(:protected)
 
   belongs_to :container, links: {
     related: proc { |b| urls.url_for(b.container) }

--- a/app/serializers/container_serializer.rb
+++ b/app/serializers/container_serializer.rb
@@ -3,6 +3,8 @@ require 'concerns/serializes_with_tagged_scope'
 class ContainerSerializer < ApplicationSerializer
   include SerializesWithTaggedScope
 
+  attribute(:restricted)
+
   link(:self) { |c| urls.url_for(c) }
 
   has_many :blobs, links: {

--- a/db/migrate/20190328130432_add_restricted_tags.rb
+++ b/db/migrate/20190328130432_add_restricted_tags.rb
@@ -1,0 +1,5 @@
+class AddRestrictedTags < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tags, :restricted?, :boolean, default: false
+  end
+end

--- a/db/migrate/20190328132425_add_protected_blobs.rb
+++ b/db/migrate/20190328132425_add_protected_blobs.rb
@@ -1,0 +1,5 @@
+class AddProtectedBlobs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :blobs, :protected?, :boolean, default: false
+  end
+end

--- a/db/migrate/20190328144310_remove_question_mark_from_db.rb
+++ b/db/migrate/20190328144310_remove_question_mark_from_db.rb
@@ -1,0 +1,6 @@
+class RemoveQuestionMarkFromDb < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :blobs, :protected?, :protected
+    rename_column :tags, :restricted?, :restricted
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_28_132425) do
+ActiveRecord::Schema.define(version: 2019_03_28_144310) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 2019_03_28_132425) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "container_id", null: false
-    t.boolean "protected?", default: false
+    t.boolean "protected", default: false
     t.index ["container_id"], name: "index_blobs_on_container_id"
   end
 
@@ -68,7 +68,7 @@ ActiveRecord::Schema.define(version: 2019_03_28_132425) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "restricted?", default: false
+    t.boolean "restricted", default: false
     t.index ["name"], name: "index_tags_on_name", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_27_162348) do
+ActiveRecord::Schema.define(version: 2019_03_28_130432) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,6 +67,7 @@ ActiveRecord::Schema.define(version: 2019_03_27_162348) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "restricted?", default: false
     t.index ["name"], name: "index_tags_on_name", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_28_130432) do
+ActiveRecord::Schema.define(version: 2019_03_28_132425) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 2019_03_28_130432) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "container_id", null: false
+    t.boolean "protected?", default: false
     t.index ["container_id"], name: "index_blobs_on_container_id"
   end
 


### PR DESCRIPTION
The authorisation has been updated so that objects are `readable` and `writable`. This implemented on the `Blob`, `Container`, and `Blob` level. Look through the commits for full details on how the three levels interact. In short, the rules are:

0. Global admins are super users and can do anything
1. A user can never write to a restricted container (more on this latter)
2. Otherwise a user can read/write to any container they directly own
3. A user can never write to a public container
4. Otherwise they can read/write to any container they have group level access to
5. Users can never write to a protected blob (more on this latter)
6. Otherwise the read/write access control to a Blob is dictated by its Container

The `read` actions are `show`, `index`, and `download`. The `write` actions are `upload` and `destroy`. 

Certain tags can be flagged as `restricted`. This means the corresponding containers can only be uploaded to by an `admin`. It also gives their blobs `protected` status.

A `protected` blob is one that can not be deleted by a regular user. This is either through a restricted container OR individually flagged on the Blob. fixes #11 fixes #12 