### PR TITLE
Update the scoping to be more flexible

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,277 @@
+Eclipse Public License - v 2.0
+
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+  a) in the case of the initial Contributor, the initial content
+     Distributed under this Agreement, and
+
+  b) in the case of each subsequent Contributor:
+     i) changes to the Program, and
+     ii) additions to the Program;
+  where such changes and/or additions to the Program originate from
+  and are Distributed by that particular Contributor. A Contribution
+  "originates" from a Contributor if it was added to the Program by
+  such Contributor itself or anyone acting on such Contributor's behalf.
+  Contributions do not include changes or additions to the Program that
+  are not Modified Works.
+
+"Contributor" means any person or entity that Distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which
+are necessarily infringed by the use or sale of its Contribution alone
+or when combined with the Program.
+
+"Program" means the Contributions Distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement
+or any Secondary License (as applicable), including Contributors.
+
+"Derivative Works" shall mean any work, whether in Source Code or other
+form, that is based on (or derived from) the Program and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+
+"Modified Works" shall mean any work in Source Code or other form that
+results from an addition to, deletion from, or modification of the
+contents of the Program, including, for purposes of clarity any new file
+in Source Code form that contains any contents of the Program. Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program solely
+in each case in order to link to, bind by name, or subclass the Program
+or Modified Works thereof.
+
+"Distribute" means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+
+"Source Code" means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+
+"Secondary License" means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including any
+exceptions or additional permissions as identified by the initial
+Contributor.
+
+2. GRANT OF RIGHTS
+
+  a) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free copyright
+  license to reproduce, prepare Derivative Works of, publicly display,
+  publicly perform, Distribute and sublicense the Contribution of such
+  Contributor, if any, and such Derivative Works.
+
+  b) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free patent
+  license under Licensed Patents to make, use, sell, offer to sell,
+  import and otherwise transfer the Contribution of such Contributor,
+  if any, in Source Code or other form. This patent license shall
+  apply to the combination of the Contribution and the Program if, at
+  the time the Contribution is added by the Contributor, such addition
+  of the Contribution causes such combination to be covered by the
+  Licensed Patents. The patent license shall not apply to any other
+  combinations which include the Contribution. No hardware per se is
+  licensed hereunder.
+
+  c) Recipient understands that although each Contributor grants the
+  licenses to its Contributions set forth herein, no assurances are
+  provided by any Contributor that the Program does not infringe the
+  patent or other intellectual property rights of any other entity.
+  Each Contributor disclaims any liability to Recipient for claims
+  brought by any other entity based on infringement of intellectual
+  property rights or otherwise. As a condition to exercising the
+  rights and licenses granted hereunder, each Recipient hereby
+  assumes sole responsibility to secure any other intellectual
+  property rights needed, if any. For example, if a third party
+  patent license is required to allow Recipient to Distribute the
+  Program, it is Recipient's responsibility to acquire that license
+  before distributing the Program.
+
+  d) Each Contributor represents that to its knowledge it has
+  sufficient copyright rights in its Contribution, if any, to grant
+  the copyright license set forth in this Agreement.
+
+  e) Notwithstanding the terms of any Secondary License, no
+  Contributor makes additional grants to any Recipient (other than
+  those set forth in this Agreement) as a result of such Recipient's
+  receipt of the Program under the terms of a Secondary License
+  (if permitted under the terms of Section 3).
+
+3. REQUIREMENTS
+
+3.1 If a Contributor Distributes the Program in any form, then:
+
+  a) the Program must also be made available as Source Code, in
+  accordance with section 3.2, and the Contributor must accompany
+  the Program with a statement that the Source Code for the Program
+  is available under this Agreement, and informs Recipients how to
+  obtain it in a reasonable manner on or through a medium customarily
+  used for software exchange; and
+
+  b) the Contributor may Distribute the Program under a license
+  different than this Agreement, provided that such license:
+     i) effectively disclaims on behalf of all other Contributors all
+     warranties and conditions, express and implied, including
+     warranties or conditions of title and non-infringement, and
+     implied warranties or conditions of merchantability and fitness
+     for a particular purpose;
+
+     ii) effectively excludes on behalf of all other Contributors all
+     liability for damages, including direct, indirect, special,
+     incidental and consequential damages, such as lost profits;
+
+     iii) does not attempt to limit or alter the recipients' rights
+     in the Source Code under section 3.2; and
+
+     iv) requires any subsequent distribution of the Program by any
+     party to be under a license that satisfies the requirements
+     of this section 3.
+
+3.2 When the Program is Distributed as Source Code:
+
+  a) it must be made available under this Agreement, or if the
+  Program (i) is combined with other material in a separate file or
+  files made available under a Secondary License, and (ii) the initial
+  Contributor attached to the Source Code the notice described in
+  Exhibit A of this Agreement, then the Program may be made available
+  under the terms of such Secondary Licenses, and
+
+  b) a copy of this Agreement must be included with each copy of
+  the Program.
+
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability ("notices") contained within the Program from any copy of
+the Program which they Distribute, provided that Contributors may add
+their own appropriate notices.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor includes
+the Program in a commercial product offering, such Contributor
+("Commercial Contributor") hereby agrees to defend and indemnify every
+other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits
+and other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program
+in a commercial product offering. The obligations in this section do not
+apply to any claims or Losses relating to any actual or alleged
+intellectual property infringement. In order to qualify, an Indemnified
+Contributor must: a) promptly notify the Commercial Contributor in
+writing of such claim, and b) allow the Commercial Contributor to control,
+and cooperate with the Commercial Contributor in, the defense and any
+related settlement negotiations. The Indemnified Contributor may
+participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those performance
+claims and warranties, and if a court requires any other Contributor to
+pay any damages as a result, the Commercial Contributor must pay
+those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed to the
+minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other software
+or hardware) infringes such Recipient's patent(s), then such Recipient's
+rights granted under Section 2(b) shall terminate as of the date such
+litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of
+time after becoming aware of such noncompliance. If all Recipient's
+rights under this Agreement terminate, Recipient agrees to cease use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient's obligations under this Agreement and any licenses
+granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions) of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may assign the
+responsibility to serve as the Agreement Steward to a suitable separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always be
+Distributed subject to the version of the Agreement under which it was
+received. In addition, after a new version of the Agreement is published,
+Contributor may elect to Distribute the Program (including its
+Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted
+under this Agreement are reserved. Nothing in this Agreement is intended
+to be enforceable by any entity that is not a Contributor or Recipient.
+No third-party beneficiary rights are created under this Agreement.
+
+Exhibit A - Form of Secondary Licenses Notice
+
+"This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set forth
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}."
+
+  Simply including a copy of this Agreement, including this Exhibit A
+  is not sufficient to license the Source Code under Secondary Licenses.
+
+  If it is not possible or desirable to put the notice in a particular
+  file, then You may include the notice in a location (such as a LICENSE
+  file in a relevant directory) where a recipient would be likely to
+  look for such a notice.
+
+  You may add additional accurate notices of copyright ownership.

--- a/README.md
+++ b/README.md
@@ -41,3 +41,11 @@ your credentials must be sent with every request. This makes using the
 The easiest work around is the set your `flight_sso` token as a cookie. This
 way it will automatically be sent with each request.
 
+# License
+Eclipse Public License 2.0, see LICENSE.txt for details.
+
+Copyright (C) 2019-present Alces Flight Ltd.
+
+This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which is available at https://www.eclipse.org/legal/epl-2.0, or alternative license terms made available by Alces Flight Ltd - please direct inquiries about licensing to licensing@alces-flight.com.
+
+flight-cache-server is distributed in the hope that it will be useful, but WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more details.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
 require 'json_web_token'
 require 'errors'
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,6 +58,10 @@ class ApplicationController < ActionController::Base
     render json: { 'error' => e.message }, status: 413
   end
 
+  rescue_from InvalidScope do |e|
+    render json: { 'error' => e.message }, status: 404
+  end
+
   def public_group
     Group.find_by_name('public')
   end

--- a/app/controllers/blobs_controller.rb
+++ b/app/controllers/blobs_controller.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
 require 'active_storage/blob'
 
 class BlobsController < ApplicationController

--- a/app/controllers/concerns/has_tagged_container.rb
+++ b/app/controllers/concerns/has_tagged_container.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
 module HasTaggedContainer
   extend ActiveSupport::Concern
 

--- a/app/controllers/containers_controller.rb
+++ b/app/controllers/containers_controller.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
 class ContainersController < ApplicationController
   before_action(only: :index) do
     @containers ||= if current_scope

--- a/app/controllers/tagged/blobs_controller.rb
+++ b/app/controllers/tagged/blobs_controller.rb
@@ -1,3 +1,29 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
 
 module Tagged
   class BlobsController < ApplicationController

--- a/app/controllers/tagged/containers_controller.rb
+++ b/app/controllers/tagged/containers_controller.rb
@@ -1,3 +1,29 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
 
 module Tagged
   class ContainersController < ApplicationController

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
 class TagsController < ApplicationController
   def index
     render json: TagSerializer.new(Tag.all, is_collection: true)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,29 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
 module ApplicationHelper
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
 class Ability
   include CanCan::Ability
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 

--- a/app/models/blob.rb
+++ b/app/models/blob.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
 class Blob < ApplicationRecord
   def self.upload_and_create!(io:, filename:, container:)
     container.raise_if_exceeds_max_size(io)

--- a/app/models/concerns/has_container_ownership.rb
+++ b/app/models/concerns/has_container_ownership.rb
@@ -1,3 +1,29 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
 
 class HasContainerOwnership < Module
   OwnershipStruct = Struct.new(:containers) do

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
 require 'aws-sdk-s3'
 require 'errors'
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
 class Group < ApplicationRecord
   include HasContainerOwnership.new(:containers)
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
 class Tag < ApplicationRecord
   has_many :containers
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
 
 require 'errors'
 

--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
 class ApplicationSerializer
   include FastJsonapi::ObjectSerializer
 

--- a/app/serializers/blob_serializer.rb
+++ b/app/serializers/blob_serializer.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
 require 'concerns/serializes_with_tagged_scope'
 
 class BlobSerializer < ApplicationSerializer

--- a/app/serializers/concerns/serializes_with_tagged_scope.rb
+++ b/app/serializers/concerns/serializes_with_tagged_scope.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
 module SerializesWithTaggedScope
   extend ActiveSupport::Concern
 

--- a/app/serializers/container_serializer.rb
+++ b/app/serializers/container_serializer.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
 require 'concerns/serializes_with_tagged_scope'
 
 class ContainerSerializer < ApplicationSerializer

--- a/app/serializers/tag_serializer.rb
+++ b/app/serializers/tag_serializer.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
 class TagSerializer < ApplicationSerializer
   attribute :name
 end

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,31 @@
 #!/usr/bin/env ruby
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
 begin
   load File.expand_path('../spring', __FILE__)
 rescue LoadError => e

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -1,4 +1,31 @@
 
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
 class ApplicationError < StandardError; end
 class UserMissing < ApplicationError; end
 class GroupMissing < ApplicationError; end

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -3,17 +3,4 @@ class ApplicationError < StandardError; end
 class UserMissing < ApplicationError; end
 class GroupMissing < ApplicationError; end
 
-class InvalidScope < ApplicationError
-  SCOPES = [:user, :group, :public]
-
-  def self.raise_unless_valid(scope)
-    return if SCOPES.include?(scope)
-    msg = <<~ERROR.squish
-      '#{scope}' is not a valid scope! The valid scopes are:
-      #{SCOPES.map(&:to_s)}
-    ERROR
-    raise new(msg)
-  end
-end
-
 class UploadTooLarge < ApplicationError; end

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -4,3 +4,4 @@ class UserMissing < ApplicationError; end
 class GroupMissing < ApplicationError; end
 
 class UploadTooLarge < ApplicationError; end
+class InvalidScope < ApplicationError; end

--- a/lib/scope_parser.rb
+++ b/lib/scope_parser.rb
@@ -1,0 +1,7 @@
+ScopeParser = Struct.new(:current_user) do
+  def parse(scope)
+    if scope == :user
+      current_user
+    end
+  end
+end

--- a/lib/scope_parser.rb
+++ b/lib/scope_parser.rb
@@ -10,6 +10,8 @@ ScopeParser = Struct.new(:current_user) do
       global_group
     when current_user.email
       current_user
+    when current_user.default_group.name
+      current_user.default_group
     end
   end
 

--- a/lib/scope_parser.rb
+++ b/lib/scope_parser.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
 ScopeParser = Struct.new(:current_user) do
   def parse(scope)
     return nil if scope.blank?

--- a/lib/scope_parser.rb
+++ b/lib/scope_parser.rb
@@ -12,10 +12,15 @@ ScopeParser = Struct.new(:current_user) do
       current_user
     when current_user.default_group&.name
       current_user.default_group
-    end
+    end || parse_admin(scope)
   end
 
   private
+
+  def parse_admin(scope)
+    return nil unless current_user.global_admin?
+    User.find_by_email(scope)
+  end
 
   def global_group
     Group.find_or_create_by!(name: 'global')

--- a/lib/scope_parser.rb
+++ b/lib/scope_parser.rb
@@ -10,7 +10,7 @@ ScopeParser = Struct.new(:current_user) do
       global_group
     when current_user.email
       current_user
-    when current_user.default_group.name
+    when current_user.default_group&.name
       current_user.default_group
     end
   end

--- a/lib/scope_parser.rb
+++ b/lib/scope_parser.rb
@@ -1,5 +1,6 @@
 ScopeParser = Struct.new(:current_user) do
   def parse(scope)
+    return nil if scope.blank?
     scope = scope.to_s
     case scope
     when 'user'
@@ -12,7 +13,12 @@ ScopeParser = Struct.new(:current_user) do
       current_user
     when current_user.default_group&.name
       current_user.default_group
-    end || parse_admin(scope)
+    else
+      parse_admin(scope)
+    end.tap do |obj|
+      next if obj
+      raise InvalidScope, "Could not resolve the scope: #{scope}"
+    end
   end
 
   private

--- a/lib/scope_parser.rb
+++ b/lib/scope_parser.rb
@@ -1,7 +1,18 @@
 ScopeParser = Struct.new(:current_user) do
   def parse(scope)
-    if scope == :user
+    case scope
+    when :user
       current_user
+    when :group
+      current_user.default_group
+    when :global
+      global_group
     end
+  end
+
+  private
+
+  def global_group
+    Group.find_or_create_by!(name: 'global')
   end
 end

--- a/lib/scope_parser.rb
+++ b/lib/scope_parser.rb
@@ -1,12 +1,15 @@
 ScopeParser = Struct.new(:current_user) do
   def parse(scope)
+    scope = scope.to_s
     case scope
-    when :user
+    when 'user'
       current_user
-    when :group
+    when 'group'
       current_user.default_group
-    when :global
+    when 'global'
       global_group
+    when current_user.email
+      current_user
     end
   end
 

--- a/lib/scope_parser.rb
+++ b/lib/scope_parser.rb
@@ -19,7 +19,7 @@ ScopeParser = Struct.new(:current_user) do
 
   def parse_admin(scope)
     return nil unless current_user.global_admin?
-    User.find_by_email(scope)
+    User.find_by_email(scope) || Group.find_by_name(scope)
   end
 
   def global_group

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
   factory :user do
     email { "user@example.com" }
     global_admin { false }
-    group
+    default_group { build(:group) }
   end
 
   factory :blob do

--- a/spec/lib/scope_parser_spec.rb
+++ b/spec/lib/scope_parser_spec.rb
@@ -3,11 +3,12 @@ require 'scope_parser'
 
 RSpec.describe ScopeParser do
   subject { described_class.new(current_user) }
+  let(:other_user) { create(:user, email: 'other-user@example.com') }
 
-  context 'when the current_user is a regular user' do
-    let(:current_user) { build(:user) }
+  describe '#parse' do
+    context 'when the current_user is a regular user' do
+      let(:current_user) { build(:user) }
 
-    describe '#parse' do
       it 'returns nil for nil' do
         expect(subject.parse(nil)).to eq(nil)
       end
@@ -29,6 +30,10 @@ RSpec.describe ScopeParser do
         expect(subject.parse(group.name)).to eq(group)
       end
 
+      it 'can not parse the other user' do
+        expect(subject.parse(other_user.email)).to eq(nil)
+      end
+
       context 'when parsing the :global scope' do
         it 'returns a group' do
           expect(subject.parse(:global)).to be_a(Group)
@@ -37,6 +42,14 @@ RSpec.describe ScopeParser do
         it 'is named global' do
           expect(subject.parse(:global).name).to eq('global')
         end
+      end
+    end
+
+    context 'when the current user is an admin' do
+      let(:current_user) { build(:user, global_admin: true) }
+
+      it 'can parse other users by email' do
+        expect(subject.parse(other_user.email)).to eq(other_user)
       end
     end
   end

--- a/spec/lib/scope_parser_spec.rb
+++ b/spec/lib/scope_parser_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe ScopeParser do
     let(:current_user) { build(:user) }
 
     describe '#parse' do
+      it 'returns nil for nil' do
+        expect(subject.parse(nil)).to eq(nil)
+      end
+
       it 'returns the user model for :user' do
         expect(subject.parse(:user)).to eq(current_user)
       end

--- a/spec/lib/scope_parser_spec.rb
+++ b/spec/lib/scope_parser_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe ScopeParser do
         expect(subject.parse(:group)).to eq(current_user.default_group)
       end
 
+      it 'returns the current_user when email matches' do
+        expect(subject.parse(current_user.email)).to eq(current_user)
+      end
+
       context 'when parsing the :global scope' do
         it 'returns a group' do
           expect(subject.parse(:global)).to be_a(Group)

--- a/spec/lib/scope_parser_spec.rb
+++ b/spec/lib/scope_parser_spec.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
 require 'rails_helper'
 require 'scope_parser'
 

--- a/spec/lib/scope_parser_spec.rb
+++ b/spec/lib/scope_parser_spec.rb
@@ -4,6 +4,7 @@ require 'scope_parser'
 RSpec.describe ScopeParser do
   subject { described_class.new(current_user) }
   let(:other_user) { create(:user, email: 'other-user@example.com') }
+  let(:other_group) { create(:group, name: 'other-group-name') }
 
   describe '#parse' do
     context 'when the current_user is a regular user' do
@@ -34,6 +35,10 @@ RSpec.describe ScopeParser do
         expect(subject.parse(other_user.email)).to eq(nil)
       end
 
+      it 'can not parse the other group' do
+        expect(subject.parse(other_group.name)).to eq(nil)
+      end
+
       context 'when parsing the :global scope' do
         it 'returns a group' do
           expect(subject.parse(:global)).to be_a(Group)
@@ -50,6 +55,10 @@ RSpec.describe ScopeParser do
 
       it 'can parse other users by email' do
         expect(subject.parse(other_user.email)).to eq(other_user)
+      end
+
+      it 'can parse other groups by name' do
+        expect(subject.parse(other_group.name)).to eq(other_group)
       end
     end
   end

--- a/spec/lib/scope_parser_spec.rb
+++ b/spec/lib/scope_parser_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+require 'scope_parser'
+
+RSpec.describe ScopeParser do
+  subject { described_class.new(current_user) }
+
+  context 'when the current_user is a regular user' do
+    let(:current_user) { build(:user) }
+
+    describe '#parse' do
+      it 'returns the user model for :user' do
+        expect(subject.parse(:user)).to eq(current_user)
+      end
+    end
+  end
+end

--- a/spec/lib/scope_parser_spec.rb
+++ b/spec/lib/scope_parser_spec.rb
@@ -11,6 +11,20 @@ RSpec.describe ScopeParser do
       it 'returns the user model for :user' do
         expect(subject.parse(:user)).to eq(current_user)
       end
+
+      it "returns the user's group for :group" do
+        expect(subject.parse(:group)).to eq(current_user.default_group)
+      end
+
+      context 'when parsing the :global scope' do
+        it 'returns a group' do
+          expect(subject.parse(:global)).to be_a(Group)
+        end
+
+        it 'is named global' do
+          expect(subject.parse(:global).name).to eq('global')
+        end
+      end
     end
   end
 end

--- a/spec/lib/scope_parser_spec.rb
+++ b/spec/lib/scope_parser_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe ScopeParser do
         expect(subject.parse(current_user.email)).to eq(current_user)
       end
 
+      it 'returns the group when the name matches' do
+        group = current_user.default_group
+        expect(subject.parse(group.name)).to eq(group)
+      end
+
       context 'when parsing the :global scope' do
         it 'returns a group' do
           expect(subject.parse(:global)).to be_a(Group)

--- a/spec/lib/scope_parser_spec.rb
+++ b/spec/lib/scope_parser_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe ScopeParser do
         expect(subject.parse(nil)).to eq(nil)
       end
 
+      it 'returns nil for empty string' do
+        expect(subject.parse('')).to eq(nil)
+      end
+
       it 'returns the user model for :user' do
         expect(subject.parse(:user)).to eq(current_user)
       end
@@ -32,11 +36,15 @@ RSpec.describe ScopeParser do
       end
 
       it 'can not parse the other user' do
-        expect(subject.parse(other_user.email)).to eq(nil)
+        expect do
+          subject.parse(other_user.email)
+        end.to raise_error(InvalidScope)
       end
 
       it 'can not parse the other group' do
-        expect(subject.parse(other_group.name)).to eq(nil)
+        expect do
+          subject.parse(other_group.name)
+        end.to raise_error(InvalidScope)
       end
 
       context 'when parsing the :global scope' do


### PR DESCRIPTION
This fixes #23. The `user/` and `group/` prefixes have not been implemented as discussed in the original issue. Currently users do not have a `name` field as the `sso` token only contains the email. Whilst it would be possible to assume the name from the email, this does not feel correct.

Instead, the scope can either be `user` or `<user email>`. This means the group scope could be `group` or `<group name>`. This also disambiguates the use cases enough to justify dropping the prefixes.

Also use EPL. fixes #21 