### PR TITLE
General refactoring to make room for future features

### DIFF
--- a/app/models/blob.rb
+++ b/app/models/blob.rb
@@ -32,7 +32,7 @@ class Blob < ApplicationRecord
     Quotas.new(io, container).enforce_all
     transaction do
       as = ActiveStorage::Blob.create_after_upload!(io: io, filename: filename)
-      create!(active_storage_blob: as, container: container)
+      create!(active_storage_blob: as, container: container, filename: filename)
     end
   end
 

--- a/app/models/blob.rb
+++ b/app/models/blob.rb
@@ -25,10 +25,11 @@
 # https://github.com/alces-software/flight-cache-server
 #===============================================================================
 
+require 'quotas'
+
 class Blob < ApplicationRecord
   def self.upload_and_create!(io:, filename:, container:)
-    container.raise_if_exceeds_max_size(io)
-    container.user.raise_if_exceeds_limit(io) if container.user
+    Quotas.new(io, container).enforce_all
     transaction do
       as = ActiveStorage::Blob.create_after_upload!(io: io, filename: filename)
       create!(active_storage_blob: as, container: container)

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -37,7 +37,7 @@ class Container < ApplicationRecord
     validates owner1, presence: true, unless: owner2
   end
 
-  delegate :max_size, :restricted, :restricted?, to: :tag
+  delegate :restricted, :restricted?, to: :tag
 
   has_many :blobs
   belongs_to :tag
@@ -63,14 +63,6 @@ class Container < ApplicationRecord
 
   def owner
     user || group
-  end
-
-  def raise_if_exceeds_max_size(io)
-    return if io.size < max_size
-    raise UploadTooLarge, <<~ERROR.squish
-      Can not upload the file as the maximum size is #{max_size}B, but the file
-      is #{io.size}B
-    ERROR
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,12 +68,4 @@ class User < ApplicationRecord
   def remaining_limit
     upload_limit - used_limit
   end
-
-  def raise_if_exceeds_limit(io)
-    return if io.size < remaining_limit
-    raise UploadTooLarge, <<~ERROR.squish
-      Can not upload file as it will exceeded your personal quota. The file is
-      #{io.size}B but you only have #{remaining_limit}B remaining.
-    ERROR
-  end
 end

--- a/db/migrate/20190408140911_split_blob_id_and_as_blob_ref.rb
+++ b/db/migrate/20190408140911_split_blob_id_and_as_blob_ref.rb
@@ -1,0 +1,6 @@
+class SplitBlobIdAndAsBlobRef < ActiveRecord::Migration[5.2]
+  def change
+    execute "ALTER TABLE blobs DROP CONSTRAINT blobs_pkey"
+    add_column :blobs, :id, :primary_key
+  end
+end

--- a/db/migrate/20190410112920_make_active_storage_blobs_unique.rb
+++ b/db/migrate/20190410112920_make_active_storage_blobs_unique.rb
@@ -1,0 +1,5 @@
+class MakeActiveStorageBlobsUnique < ActiveRecord::Migration[5.2]
+  def change
+    add_index :blobs, :active_storage_blob_id, unique: true
+  end
+end

--- a/db/migrate/20190412134055_add_blob_filename_and_title.rb
+++ b/db/migrate/20190412134055_add_blob_filename_and_title.rb
@@ -1,0 +1,6 @@
+class AddBlobFilenameAndTitle < ActiveRecord::Migration[5.2]
+  def change
+    add_column :blobs, :title, :string
+    add_column :blobs, :filename, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_02_190218) do
+ActiveRecord::Schema.define(version: 2019_04_08_140911) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,7 +36,8 @@ ActiveRecord::Schema.define(version: 2019_04_02_190218) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "blobs", primary_key: "active_storage_blob_id", id: :serial, force: :cascade do |t|
+  create_table "blobs", force: :cascade do |t|
+    t.serial "active_storage_blob_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "container_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_08_140911) do
+ActiveRecord::Schema.define(version: 2019_04_10_112920) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,6 +42,7 @@ ActiveRecord::Schema.define(version: 2019_04_08_140911) do
     t.datetime "updated_at", null: false
     t.bigint "container_id", null: false
     t.boolean "protected", default: false
+    t.index ["active_storage_blob_id"], name: "index_blobs_on_active_storage_blob_id", unique: true
     t.index ["container_id"], name: "index_blobs_on_container_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_10_112920) do
+ActiveRecord::Schema.define(version: 2019_04_12_134055) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,6 +42,8 @@ ActiveRecord::Schema.define(version: 2019_04_10_112920) do
     t.datetime "updated_at", null: false
     t.bigint "container_id", null: false
     t.boolean "protected", default: false
+    t.string "title"
+    t.string "filename"
     t.index ["active_storage_blob_id"], name: "index_blobs_on_active_storage_blob_id", unique: true
     t.index ["container_id"], name: "index_blobs_on_container_id"
   end

--- a/lib/quotas.rb
+++ b/lib/quotas.rb
@@ -1,0 +1,38 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
+require 'errors'
+
+Quotas = Struct.new(:io, :container) do
+  def enforce_tag_limit
+    return if io.size < container.tag.max_size
+    raise UploadTooLarge, <<~ERROR.squish
+      Can not upload the file as the maximum size is #{container.tag.max_size}B,
+      but the file is #{io.size}B
+    ERROR
+  end
+end

--- a/lib/quotas.rb
+++ b/lib/quotas.rb
@@ -27,7 +27,12 @@
 
 require 'errors'
 
-Quotas = Struct.new(:io, :container) do
+Quotas = Struct.new(:io, :container, :offset) do
+  def initialize(*a)
+    super
+    self.offset ||= 0
+  end
+
   def enforce_tag_limit
     return if io.size < container.tag.max_size
     raise UploadTooLarge, <<~ERROR.squish
@@ -38,7 +43,7 @@ Quotas = Struct.new(:io, :container) do
 
   def enforce_user_limit
     return unless container.user
-    return if io.size < container.user.remaining_limit
+    return if io.size - offset < container.user.remaining_limit
     raise UploadTooLarge, <<~ERROR.squish
       Can not upload file as it will exceeded your personal quota. The file is
       #{io.size}B but you only have #{container.user.remaining_limit}B

--- a/lib/quotas.rb
+++ b/lib/quotas.rb
@@ -33,6 +33,11 @@ Quotas = Struct.new(:io, :container, :offset) do
     self.offset ||= 0
   end
 
+  def enforce_all
+    enforce_tag_limit
+    enforce_user_limit
+  end
+
   def enforce_tag_limit
     return if io.size < container.tag.max_size
     raise UploadTooLarge, <<~ERROR.squish

--- a/lib/quotas.rb
+++ b/lib/quotas.rb
@@ -48,11 +48,11 @@ Quotas = Struct.new(:io, :container, :offset) do
 
   def enforce_user_limit
     return unless container.user
-    return if io.size - offset < container.user.remaining_limit
+    remaining_limit = container.user.remaining_limit + offset
+    return if io.size < remaining_limit
     raise UploadTooLarge, <<~ERROR.squish
       Can not upload file as it will exceeded your personal quota. The file is
-      #{io.size}B but you only have #{container.user.remaining_limit}B
-      remaining.
+      #{io.size}B but you only have #{remaining_limit}B remaining.
     ERROR
   end
 end

--- a/lib/quotas.rb
+++ b/lib/quotas.rb
@@ -31,8 +31,18 @@ Quotas = Struct.new(:io, :container) do
   def enforce_tag_limit
     return if io.size < container.tag.max_size
     raise UploadTooLarge, <<~ERROR.squish
-      Can not upload the file as the maximum size is #{container.tag.max_size}B,
-      but the file is #{io.size}B
+      Can not upload the file as the maximum size is
+      #{container.tag.max_size}B, but the file is #{io.size}B
+    ERROR
+  end
+
+  def enforce_user_limit
+    return unless container.user
+    return if io.size < container.user.remaining_limit
+    raise UploadTooLarge, <<~ERROR.squish
+      Can not upload file as it will exceeded your personal quota. The file is
+      #{io.size}B but you only have #{container.user.remaining_limit}B
+      remaining.
     ERROR
   end
 end

--- a/spec/lib/quotas_spec.rb
+++ b/spec/lib/quotas_spec.rb
@@ -33,10 +33,14 @@ RSpec.describe Quotas do
   let(:payload) { 'a' * size }
   let(:io) { StringIO.new(payload) }
 
+  # Either the user/group must be overridden in each context
+  let(:user) { nil }
+  let(:group) { nil }
+  let(:container) { build(:container, user: user, group: group) }
+
   subject { described_class.new(io, container) }
 
-  context 'with an empty file' do
-    let(:container) { build(:container) }
+  shared_examples 'an empty file quota' do
     let(:size) { 0 }
 
     describe '#enforce_tag_limit' do
@@ -48,7 +52,7 @@ RSpec.describe Quotas do
     end
   end
 
-  context 'when the file size exceeds the container limit' do
+  shared_examples 'an excessive tag quota' do
     let(:container) { build(:container) }
     let(:size) { container.tag.max_size + 1 }
 
@@ -59,5 +63,19 @@ RSpec.describe Quotas do
         end.to raise_error(UploadTooLarge)
       end
     end
+  end
+
+  context 'with a user container' do
+    let(:user) { build(:user) }
+
+    it_behaves_like 'an empty file quota'
+    it_behaves_like 'an excessive tag quota'
+  end
+
+  context 'with a group container' do
+    let(:group) { build(:group) }
+
+    it_behaves_like 'an empty file quota'
+    it_behaves_like 'an excessive tag quota'
   end
 end

--- a/spec/lib/quotas_spec.rb
+++ b/spec/lib/quotas_spec.rb
@@ -1,0 +1,63 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of flight-cache-server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-cache-server, please visit:
+# https://github.com/alces-software/flight-cache-server
+#===============================================================================
+
+require 'rails_helper'
+require 'quotas'
+require 'stringio'
+
+RSpec.describe Quotas do
+  let(:payload) { 'a' * size }
+  let(:io) { StringIO.new(payload) }
+
+  subject { described_class.new(io, container) }
+
+  context 'with an empty file' do
+    let(:container) { build(:container) }
+    let(:size) { 0 }
+
+    describe '#enforce_tag_limit' do
+      it 'passes' do
+        expect do
+          subject.enforce_tag_limit
+        end.not_to raise_error
+      end
+    end
+  end
+
+  context 'when the file size exceeds the container limit' do
+    let(:container) { build(:container) }
+    let(:size) { container.tag.max_size + 1 }
+
+    describe '#enforce_tag_limit' do
+      it 'errors' do
+        expect do
+          subject.enforce_tag_limit
+        end.to raise_error(UploadTooLarge)
+      end
+    end
+  end
+end

--- a/spec/lib/quotas_spec.rb
+++ b/spec/lib/quotas_spec.rb
@@ -50,6 +50,14 @@ RSpec.describe Quotas do
         end.not_to raise_error
       end
     end
+
+    describe '#enforce_user_limit' do
+      it 'passes' do
+        expect do
+          subject.enforce_user_limit
+        end.not_to raise_error
+      end
+    end
   end
 
   shared_examples 'an excessive tag quota' do
@@ -70,6 +78,18 @@ RSpec.describe Quotas do
 
     it_behaves_like 'an empty file quota'
     it_behaves_like 'an excessive tag quota'
+
+    context 'when the user limit is exceeded' do
+      let(:size) { user.remaining_limit + 1 }
+
+      describe '#enforce_user_limit' do
+        it 'errors' do
+          expect do
+            subject.enforce_user_limit
+          end.to raise_error(UploadTooLarge)
+        end
+      end
+    end
   end
 
   context 'with a group container' do

--- a/spec/models/blob_spec.rb
+++ b/spec/models/blob_spec.rb
@@ -28,32 +28,4 @@
 require 'rails_helper'
 
 RSpec.describe Blob, type: :model do
-  describe '::upload_and_create!' do
-    shared_examples 'raises UploadTooLarge' do
-      it 'errors' do
-        expect do
-          described_class.upload_and_create!(
-            io: io, filename: 'test', container: container
-          )
-        end.to raise_error(UploadTooLarge)
-      end
-    end
-
-    let(:io) { StringIO.new(payload) }
-
-    context 'when the file size exceeds the max size' do
-      let(:container) { build(:container) }
-      let(:payload) { 'a' * (container.max_size + 1) }
-
-      include_examples 'raises UploadTooLarge'
-    end
-
-    context 'when exceeding a user upload limit' do
-      let(:user) { create(:user, upload_limit: 5) }
-      let(:container) { create(:container, group: nil, user: user) }
-      let(:payload) { 'a' * (user.remaining_limit + 1) }
-
-      include_examples 'raises UploadTooLarge'
-    end
-  end
 end


### PR DESCRIPTION
This PR contains various changes which will be required for future work. In short it:

1. Splits the link between `Blob` and `AS::Blob` so they no longer share and `id`. This will allow the `AS::Blob` to be replaced as part of an edit
2. The code for determining upload quotas has been extracted into a shared library. This will allow it to be reused easily during an edit as opposed to a standard upload. It also has an `offset` built into it, which will be used by `edit`
3. A `filename` and `title` field has been added to the `Blob`. These will replace the name stored on the `AS::Blob`. Eventually it will be unique, however a data migration is required first