### PR TITLE
Make filenames unique within a container

### DIFF
--- a/db/migrate/20190412142656_make_container_filenames_unique.rb
+++ b/db/migrate/20190412142656_make_container_filenames_unique.rb
@@ -1,0 +1,6 @@
+class MakeContainerFilenamesUnique < ActiveRecord::Migration[5.2]
+  def change
+    add_index :blobs, [:filename, :container_id], unique: true
+    change_column :blobs, :filename, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_12_134055) do
+ActiveRecord::Schema.define(version: 2019_04_12_142656) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,9 +43,10 @@ ActiveRecord::Schema.define(version: 2019_04_12_134055) do
     t.bigint "container_id", null: false
     t.boolean "protected", default: false
     t.string "title"
-    t.string "filename"
+    t.string "filename", null: false
     t.index ["active_storage_blob_id"], name: "index_blobs_on_active_storage_blob_id", unique: true
     t.index ["container_id"], name: "index_blobs_on_container_id"
+    t.index ["filename", "container_id"], name: "index_blobs_on_filename_and_container_id", unique: true
   end
 
   create_table "containers", force: :cascade do |t|


### PR DESCRIPTION
This will be used to make finding blobs easier as they can be indexed against the container. The migration is being merged now so the `db` is ready for the features to be built on top of it