### PR TITLE
Remove the missing active storage blob error

### DIFF
--- a/app/models/blob.rb
+++ b/app/models/blob.rb
@@ -45,7 +45,7 @@ class Blob < ApplicationRecord
 
   belongs_to :container
   belongs_to :active_storage_blob, class_name: 'ActiveStorage::Blob', optional: true
-  delegate_missing_to :active_storage_blob_or_error
+  delegate_missing_to :active_storage_blob
 
   validates :filename, uniqueness: { scope: :container }
   validates :label, format: {
@@ -74,10 +74,6 @@ class Blob < ApplicationRecord
       new_as.purge
       raise e
     end
-  end
-
-  def active_storage_blob_or_error
-    active_storage_blob || MissingActiveStorageBlob.raise(self)
   end
 
   def protected

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -48,11 +48,3 @@ class MissingBlobError < MissingError
     ERROR
   end
 end
-
-class MissingActiveStorageBlob < MissingError
-  def self.raise(blob)
-    Kernel.raise self, <<~ERROR
-      File '#{blob.id}' is not associated with an uploaded file
-    ERROR
-  end
-end


### PR DESCRIPTION
This should never happen long in practice, but their is a point in the
update process that the `Blob` is saved without an associated
`AS::Blob`.

This can be revisited if it starts to cause issues