### PR TITLE
Fix the bad token error and setting of the admin flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ your credentials must be sent with every request. This makes using the
 The easiest work around is the set your `flight_sso` token as a cookie. This
 way it will automatically be sent with each request.
 
+# Manually creating a user token
+
+Tokens to access the server are typically generated using `flight-sso` or
+`flight-account`. If these services are not available, tokens can be manually
+generated through the rails console:
+
+```
+> rails console
+> user = User.find_by_email(<YOUR-EMAIL-ADDRESS>)
+> JsonWebToken::Builder.new(user).build
+=> ... # Returns an SSO token that is valid for 24 hrs
+```
+
 # License
 Eclipse Public License 2.0, see LICENSE.txt for details.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This app uses figaro to configure certain components. The following needs to be
 set in the environment or via a figaro config file:
 
 ```
+> vim config/application.yml
+
 default_bucket:         # The S3 bucket the files are stored in
 default_region:         # The S3 region to use
 json_web_token_secret:  # The secret key for checking token signatures

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -66,6 +66,10 @@ class ApplicationController < ActionController::Base
     render json: { 'error' => e.message }, status: 400
   end
 
+  rescue_from BadTokenError do |e|
+    render json: { 'error' => e.message }, status: 401
+  end
+
   def current_user
     token_param.user || raise(UserMissing)
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -100,7 +100,7 @@ class ApplicationController < ActionController::Base
 
   def admin_request
     if current_user.global_admin?
-      params['admin'] || false
+      [true, 'true'].include?(params['admin'])
     else
       false
     end

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -48,3 +48,11 @@ class MissingBlobError < MissingError
     ERROR
   end
 end
+
+class BadTokenError < ApplicationError
+  MESSAGE = 'Your token is either invalid or expired'
+
+  def initialize(msg = MESSAGE)
+    super
+  end
+end

--- a/lib/json_web_token.rb
+++ b/lib/json_web_token.rb
@@ -10,16 +10,13 @@
 # http://zacstewart.com/2015/05/14/using-json-web-tokens-to-authenticate-javascript-front-ends-on-rails.html
 #
 require 'jwt'
+require 'errors'
 
 class JsonWebToken
   Token = Struct.new(:token) do
     def initialize(*a)
       super
       data
-    end
-
-    def error?
-      @error
     end
 
     def email
@@ -35,8 +32,7 @@ class JsonWebToken
     def data
       @data ||= JsonWebToken.decode(token).deep_symbolize_keys
     rescue
-      @error ||= true
-      @data ||= {}
+      raise BadTokenError
     end
   end
 


### PR DESCRIPTION
An expired token wasn't generating an error which resulted in weirdness. This has been fixed

Also setting of the `admin_flag` is now more explicitly to prevent random strings defaulting to true

The README has been updated with additional notes